### PR TITLE
Improvement for histogram display and fext fitting

### DIFF
--- a/FitHelper.h
+++ b/FitHelper.h
@@ -108,8 +108,8 @@ char ctem;
 
 	SetParLimitAuto(ftemp,_Norder);
 
-	for(int i=0;i<10;i++){
-		if(i<2 || i>9) h_random->Fit(ftemp,"MNQ","",fitlowedge,fithighedge);
+	for(int i=0;i<15;i++){
+		if(i<3 || i>14) h_random->Fit(ftemp,"MNQ","",fitlowedge,fithighedge);
 		else h_random->Fit(ftemp,"LMNQ","",fitlowedge,fithighedge);
 		SetParLimitAuto(ftemp,_Norder);
 
@@ -133,8 +133,8 @@ sleep(1); // Seem this pause for the system can help to prevent the clash of the
 		h_random->Add((TH1*)h_sub,-1); h_random->Draw();
 		cout<<"i ="<<i<<"\r"<<flush;
 		int j=0;
-		while(j++<10){
-			if(j<3 ||j >9) h_random->Fit(ftemp,"MEQN","",fitlowedge,fithighedge);//fitopt.c_str()
+		while(j++<15){
+			if(j<3 ||j >13) h_random->Fit(ftemp,"MEQN","",fitlowedge,fithighedge);//fitopt.c_str()
 			else h_random->Fit(ftemp,"LMEQN","",fitlowedge,fithighedge);
 			SetParLimitAuto(ftemp,_Norder);
 

--- a/funcN.h
+++ b/funcN.h
@@ -39,6 +39,7 @@ public:
 		bool useMC; // MC simulation for getting fitting error
 		double sample_range_L; // half range for fit
 		double sample_range_R;
+		bool EnableFunc_refInitialize;
 
 
 		int GetNumberOfPeaks(){return NumOfPeaks;}
@@ -90,6 +91,13 @@ public:
 		}
 
 		void Initial_par_ref(TH1D* _hin, double left_range, double right_range){
+			if(!EnableFunc_refInitialize && func_ref == NULL){
+				EnableFunc_refInitialize=true;
+				cout<<endl;
+				cout<<"\e[1;31m Warnning: Reference function not exist; Automatically set EnableFunc_refInitialize-> true  by default \e[0m"<<endl;
+			}
+
+			if(!EnableFunc_refInitialize) return;
 			if(func_ref!=NULL){delete func_ref; func_ref=NULL;}
 			if(par_ref!=NULL) delete[] par_ref;
 			pars_per_peak = 5+Norder*2;
@@ -344,6 +352,8 @@ public:
 		}
 
 		void MakeFitFunc_ref(){
+			if(!EnableFunc_refInitialize){return;}			
+
 			if(func_ref!=NULL){delete func_ref; delete func_ref_cp;}
 			func_ref = new TF1("fextend_ref",this,&funcN::fitfunc,0,25e6,pars_per_peak,"1func_ref","1fitfunc_ref");
 			func_ref_cp = new TF1("fextend_ref_cp",this,&funcN::fitfunc,0,25e6,pars_per_peak,"1func_ref","1fitfunc_ref");
@@ -521,7 +531,13 @@ public:
 
 		void Fit_ref(TH1D* h_in, double _rangeL, double _rangeR, string fitopt="LMEQ"){
 
-			FitHelper(func_ref,h_in,_rangeL,_rangeR,Norder,fitopt);//return;
+			if(EnableFunc_refInitialize) FitHelper(func_ref,h_in,_rangeL,_rangeR,Norder,fitopt);//return;
+			else{
+				for(int index=0;index< pars_per_peak;index++){
+					func_ref->ReleaseParameter(index);
+				}
+			}
+
 			for(int i=0;i<50;i++){
 				h_in->Fit(func_ref,(fitopt+"N").c_str(),"",_rangeL,_rangeR);
 				if(i<40){SetParLimitAuto(func_ref,Norder);}
@@ -711,6 +727,8 @@ public:
 			FreeRange =true;
 			AutoUpdateMainPeakIndex=true;
 			useMC=false;
+
+			EnableFunc_refInitialize=true;
 		}
 
 		~funcN(){

--- a/preview5.C
+++ b/preview5.C
@@ -1067,7 +1067,8 @@ int laps_ref = 600;
 int laps_x = laps_ref;
 int q_x = 1;
 //const double KEV90 = 0.93149400380; const double err_KEV90 = 0.0004*1e-6; // 1 u = 931494.0038 KEV90, mass unit in micro u in program
-const double KEV90 = 0.93149410242; const double err_KEV90 = 0.00028*1e-6;
+const double KEV90 = 0.93149410242; const double err_KEV90 = 0.00028*1e-6; 
+const double Coeff_keV_2_uamu = 1.07354410233; const double err_Coeff_keV_2_uamu= 0.00000000032;
 //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 
 //&&&&&&&&&& variable for component mass &&&&&&&&&&&&&&&&&
@@ -1504,6 +1505,7 @@ if(!dflag)useTOFveto(veto_test);
 				h_xF->Draw();
 			}
 			else h_xF->Draw();
+
 		c1->cd(3);
 			if(dflag){//intree->Draw("time>>h_refF","tag==1");
 				h_refF->Draw();
@@ -1603,6 +1605,7 @@ if(!dflag)useTOFveto(veto_test);
 		h_xF->GetYaxis()->SetTitle(Form("counts/%.1f [ns]",(tag0H-tag0L)/binsfuspectrum));
 		h_xF->GetYaxis()->SetTitleSize(0.05);
 		h_xF->GetYaxis()->CenterTitle();
+		h_xF->SetTitle(Form("channel =%d, veto=%.1f [ns] @ %d laps",Tof_Channel2Read,Tof_veto,laps_x));
 	}	
 	if(h_refF!=NULL){
 		h_refF->GetXaxis()->SetTitle("tof[ns]");
@@ -2042,7 +2045,7 @@ void histo_zoom_in_x(int tag=0,int bins=0,double histoL=0,double histoR=0){
 	if(h_zoom_x!=NULL){delete h_zoom_x; h_zoom_x=NULL;}//h_zoom_x->Clear();
 	//if(h_zoom_x_shadow!=NULL){delete h_zoom_x_shadow;h_zoom_x_shadow=NULL;}
 
-	h_zoom_x = new TH1D("h_zoom_x",Form("X ion tag%d zoom in",tag),bins,histoL,histoR);
+	h_zoom_x = new TH1D("h_zoom_x",Form("X ion tag%d, channel %d, veto %.1f[ns] zoom in",tag,Tof_Channel2Read,Tof_veto),bins,histoL,histoR);
 	//h_zoom_x_shadow = new TH1D("h_zoom_x_shadow","X ion(tag0 or tag1) zoom in",bins,histoL,histoR);
 
 
@@ -4220,6 +4223,19 @@ double* MassExcess(double mass_value,double mass_value_err, bool verbal=true){
 		double mass_excess = mass_value - A*1e6;  // unit in micro u
 		return TokeV90(mass_excess,mass_value_err,verbal);
 		
+
+}
+
+double* keV90ToMircoAMU(double mass_keV, double mass_keV_err,bool verbal=true){
+		static double massreturn[2];
+		massreturn[0]=0; massreturn[1]=0;
+		double massuamu = mass_keV * Coeff_keV_2_uamu;
+		double massuamu_err = (mass_keV*err_Coeff_keV_2_uamu)*(mass_keV*err_Coeff_keV_2_uamu) + (Coeff_keV_2_uamu*mass_keV_err)*(Coeff_keV_2_uamu*mass_keV_err);
+		massuamu_err = TMath::Sqrt(massuamu_err);
+		if(verbal)printf("mass in mirco amu: %.5f(%.5f) uamu\n",massuamu,massuamu_err);
+		massreturn[0] = massuamu;
+		massreturn[1] = massuamu_err;
+		return massreturn;
 
 }
 


### PR DESCRIPTION
Show laps number, tag number and channel number at the title of histogram.

Adjust loop number for better "fext" fitting

Add a function to convert keV into micro-aum:
         double* keV90ToMircoAMU(double mass_keV, double mass_keV_err, bool verbal = true)